### PR TITLE
chore(renovate): adopt shared presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,17 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "timezone": "Asia/Taipei",
-  "enabledManagers": ["github-actions"],
-  "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["pin", "digest", "pinDigest","major", "minor", "patch"],
-      "automerge": true,
-      "labels": ["dependencies"]
-    }
-  ],
-  "schedule": [
-    "* 3-6 * * 6"
-  ]
+  "extends": ["local>xlionjuan/renovatebot-presets"]
 }


### PR DESCRIPTION
## Summary

- replace copied GitHub Actions configuration with `local>xlionjuan/renovatebot-presets`
- remove the manager allowlist and repository schedule
- inherit the shared trusted Action, cooldown, and CI-gated automerge policy

## Validation

- `renovate-config-validator --strict --no-global .github/renovate.json`
- `git diff --check`
- pushed through the special `renovate/reconfigure` validation branch
